### PR TITLE
chore(setup): watch less files in subdirs, only copy from module root.

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,15 +21,16 @@ paths.assetFiles = [
 // excluding abstract files/dirs starting with '_'.
 paths.srcFiles = [
 		paths.src + '*',
-		paths.srcComponents + '**/*',
-		paths.srcViews + '**/*' //,
+		paths.srcComponents + '*/*',
+		paths.srcViews + '*/*',
+		'!' + paths.src + '*/_template/*'
 //		'!' + paths.src + '_*',
 //		'!' + paths.srcComponents + '_*/*',
 //		'!' + paths.srcViews + '_*/*'
 ];
 paths.htmlFiles = paths.srcFiles.map(function(path){ return path + '.html'; });
 paths.jsFiles   = paths.srcFiles.map(function(path){ return path + '.js'; });
-paths.lessFiles = paths.srcFiles.map(function(path){ return path + '.less'; });
+paths.lessFiles = paths.srcFiles.map(function(path){ return path + '*/*.less'; });
 
 module.exports = {
 	paths: paths


### PR DESCRIPTION
should allow less files in subfolders to be watched. Also, ignore the contents of _template
