### PR TITLE
fix(browser-sync): change default values for faster browsersync server

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -318,7 +318,10 @@ function serveTask() {
 	browserSync({
 		server: {
 			baseDir: paths.dist
-		}
+		},
+		ui: false,
+		online: false,
+		open: false
 	});
 }
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -315,14 +315,7 @@ function testTask(action) {
 
 function serveTask() {
 	// http://www.browsersync.io/docs/gulp/
-	browserSync({
-		server: {
-			baseDir: paths.dist
-		},
-		ui: false,
-		online: false,
-		open: false
-	});
+	browserSync(config.browserSync);
 }
 
 function srcFiles(filetype) {

--- a/config.js
+++ b/config.js
@@ -26,15 +26,22 @@ paths.srcFiles = [
 		paths.srcComponents + '*/*',
 		paths.srcViews + '*/*',
 		'!' + paths.src + '*/_template/*'
-//		'!' + paths.src + '_*',
-//		'!' + paths.srcComponents + '_*/*',
-//		'!' + paths.srcViews + '_*/*'
 ];
 paths.htmlFiles = paths.srcFiles.map(function(path){ return path + '.html'; });
 paths.jsFiles   = paths.srcFiles.map(function(path){ return path + '.js'; });
 paths.lessFiles = paths.srcFiles.map(function(path){ return path + '*/*.less'; });
 
+var browserDefaultConfig = {
+	server: {
+			baseDir: paths.dist
+		},
+	ui: false,
+	online: false,
+	open: false
+}
+
 module.exports = {
+	browserSync: browserDefaultConfig,
 	autoprefixBrowsers: autoprefixBrowsers,
 	paths: paths
 };


### PR DESCRIPTION
Adding this default values to the browser sync server makes it faster to load.

The UI option is quite interesting but only used in few cases like testing, so there's no need to load it by default.

We are not using any of the online features that require the online option to be true.
The open option is kind of annoying, specially since less breaks the stream and you have to manually restart everything.