### PR TITLE
Simpler scaffolding command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Create your project folder and add a `package.json`. This can be done with:
 
 If you are running this on an empty folder it’s recommended to get the scaffolding files. You can do this by running:
 
-    $ node ./node_modules/front-end-guide/lib/scaffolding.js
+    $ ./node_modules/.bin/front-end-guide
+
+If you installed it globally then you can run
+
+    $ front-end-guide
 
 ## Available Tasks
 
@@ -78,4 +82,4 @@ This will optimize **new** images on the assets-raw folder and copy them to asse
 
 ## Writing README files
 
-README files are written with Markdown. Code blocks are syntax-highlighted with Prism. Currently we support four basic languages (C-like, CSS, "Markup", JavaScript). 
+README files are written with Markdown. Code blocks are syntax-highlighted with Prism. Currently we support four basic languages (C-like, CSS, "Markup", JavaScript).

--- a/bin/scaffolding
+++ b/bin/scaffolding
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var wrench = require('wrench');
 var chalk = require('chalk');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.4",
   "description": "Manage your front-end project in unique views and reusable components.",
   "main": "index.js",
+  "bin": "./bin/scaffolding",
   "repository": {
     "type": "git",
     "url": "git://github.com/voorhoede/front-end-guide.git"


### PR DESCRIPTION
By using the [`bin`](https://docs.npmjs.com/files/package.json#bin) inside `package.json`, this will allow this package to be installed globally and use a simple command to scaffold a project. If not installed globally then it will follow npm best practices by linking executable commands to be inside `./node_modules/.bin`.

I have a question regarding the project though, it is a nice project but I wonder why did you choose to re-invent the wheel instead of building a Yeoman generator for example?